### PR TITLE
Fix CODEOWNERS: replace placeholder with @L0rdS474n

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,21 +4,13 @@
 # whenever a pull request touches a matching path.  Documentation:
 #   https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
 #
-# Until the GitHub repository is created (Pass 16), the project does not
-# yet have a real maintainer handle attached to it.  We deliberately use
-# the literal placeholder @OWNER_TBD_PLACEHOLDER here so the file is
-# structurally correct and parseable by GitHub's CODEOWNERS validator,
-# while making it obvious that the handle still needs to be replaced.
+# CODEOWNERS only takes effect for handles that have write access to the
+# repository, so the maintainer below must keep admin/owner rights on
+# this repo for the auto-review-request behaviour to work.
 #
-# Pass 16 (GitHub repo bring-up) will:
-#   1. Replace @OWNER_TBD_PLACEHOLDER with the real maintainer handle.
-#   2. Confirm the user has admin/owner access on the repository so the
-#      reviews are auto-requested (CODEOWNERS only takes effect for users
-#      with write access to the repo).
-#
-# The token "@OWNER_TBD_PLACEHOLDER" is enforced by the policy test
-# AC-1.5-041 in tests/test_repo_policy.cpp.  Changing this default
-# without updating that AC is a contract break.
+# The exact handle on the default rule is enforced by the policy tests
+# AC-1.5-041 and AC-1.5-042 in tests/test_repo_policy.cpp.  Changing the
+# handle without updating those ACs (and AC-1.5-200) is a contract break.
 
 # Default owner -- everything not matched by a more specific rule.
-*       @OWNER_TBD_PLACEHOLDER
+*       @L0rdS474n

--- a/tests/test_repo_policy.cpp
+++ b/tests/test_repo_policy.cpp
@@ -315,29 +315,28 @@ TEST_CASE("AC-1.5-040: .github/CODEOWNERS exists", "[repo-policy]")
     REQUIRE(std::filesystem::exists(path));
 }
 
-TEST_CASE("AC-1.5-041: CODEOWNERS default rule references @OWNER_TBD_PLACEHOLDER", "[repo-policy]")
+TEST_CASE("AC-1.5-041: CODEOWNERS default rule references @L0rdS474n", "[repo-policy]")
 {
     const auto text = slurp(REPO_ROOT / ".github" / "CODEOWNERS");
     REQUIRE_FALSE(text.empty());
 
-    CHECK(text.find("@OWNER_TBD_PLACEHOLDER") != std::string::npos);
+    CHECK(text.find("@L0rdS474n") != std::string::npos);
 }
 
-TEST_CASE("AC-1.5-042: CODEOWNERS contains no real-looking GitHub usernames", "[repo-policy]")
+TEST_CASE("AC-1.5-042: CODEOWNERS contains only the maintainer handle", "[repo-policy]")
 {
     const auto text = slurp(REPO_ROOT / ".github" / "CODEOWNERS");
     REQUIRE_FALSE(text.empty());
 
-    // A "real-looking" username is any @handle that is NOT the explicit
-    // placeholder.  We allow @OWNER_TBD_PLACEHOLDER and nothing else.
-    // Strategy: find all @<word> tokens and reject any that differ from the
-    // placeholder.
+    // The default rule must point at the project maintainer and only the
+    // project maintainer.  Strategy: find all @<word> tokens and reject any
+    // that differ from the canonical handle.
     const std::regex at_handle(R"(@([A-Za-z0-9_\-]+))");
     auto begin = std::sregex_iterator(text.begin(), text.end(), at_handle);
     auto end   = std::sregex_iterator{};
     for (auto it = begin; it != end; ++it) {
         const std::string handle = (*it)[0].str();  // includes leading @
-        CHECK(handle == "@OWNER_TBD_PLACEHOLDER");
+        CHECK(handle == "@L0rdS474n");
     }
 }
 
@@ -681,7 +680,7 @@ TEST_CASE("AC-1.5-124: ADR-0003 contains real-world validation note", "[repo-pol
 // Cross-cutting  (AC-1.5-200 .. 202)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("AC-1.5-200: no real GitHub usernames appear outside CODEOWNERS @OWNER_TBD_PLACEHOLDER", "[repo-policy]")
+TEST_CASE("AC-1.5-200: no real GitHub usernames appear outside CODEOWNERS @L0rdS474n", "[repo-policy]")
 {
     // Check every policy file.  Any @<handle> that is not the placeholder is a
     // potential leak.  We intentionally do NOT scan build artefacts or the
@@ -707,13 +706,13 @@ TEST_CASE("AC-1.5-200: no real GitHub usernames appear outside CODEOWNERS @OWNER
         auto end   = std::sregex_iterator{};
         for (auto it = begin; it != end; ++it) {
             const std::string handle = (*it)[0].str();
-            // Allow @OWNER_TBD_PLACEHOLDER and email-like contexts (@gmail etc.)
-            // We only flag handles that look like real GitHub usernames:
-            // all-lowercase, no dots, not a known placeholder or email domain.
-            const bool is_placeholder = handle == "@OWNER_TBD_PLACEHOLDER";
-            const bool is_email_part  = handle.find('.') != std::string::npos ||
-                                        text.find(handle + ".") != std::string::npos;
-            if (!is_placeholder && !is_email_part) {
+            // Allow the canonical maintainer handle and email-like contexts
+            // (@gmail etc.).  We only flag handles that look like other real
+            // GitHub usernames slipping into policy files outside CODEOWNERS.
+            const bool is_maintainer = handle == "@L0rdS474n";
+            const bool is_email_part = handle.find('.') != std::string::npos ||
+                                       text.find(handle + ".") != std::string::npos;
+            if (!is_maintainer && !is_email_part) {
                 // Flag as a potential real username leak -- reviewer must inspect.
                 // We use WARN (not FAIL) to keep the test informative without
                 // blocking on ambiguous matches like @github or @actions.


### PR DESCRIPTION
Closes #3

## Summary

Pass 16 left `.github/CODEOWNERS` pinned to `@OWNER_TBD_PLACEHOLDER` even
after the GitHub repository was provisioned, so auto-review-requests
never fired.  This PR:

- Updates the default rule in `.github/CODEOWNERS` to `@L0rdS474n`.
- Refreshes the docstring to reflect post-bring-up state.
- Re-points `AC-1.5-041`, `AC-1.5-042`, and `AC-1.5-200` in
  `tests/test_repo_policy.cpp` at the canonical maintainer handle.

`scripts/setup-branch-protection.sh` keeps `OWNER_TBD_PLACEHOLDER` as a
fallback sentinel when `REPO_OWNER` cannot be auto-resolved -- that is
dynamic state, not a CODEOWNERS contract, and is intentionally left as is.

## Verification

- Local clean rebuild succeeds.
- `ctest` reports **439 / 439 PASSED** in 2.30s on `feature/fix-codeowners`.
- All three updated ACs (`AC-1.5-041`, `AC-1.5-042`, `AC-1.5-200`) execute
  green against the new handle.

## Test plan (CI)

- [ ] `ci-linux` green (gcc-13 build + 439/439 ctest).
- [ ] `ci-windows-cross` green (MinGW-w64 cross-compile, no test exec).
- [ ] `ci-windows-native` green (windows-latest, MSYS2 MinGW, 439/439 ctest).
- [ ] `enforce-issue-linked-pr` green (this PR closes #3).

Built with [Claude](https://www.anthropic.com/claude) following CLAUDE.md.