### PR TITLE
feat(ci-linux): upload ClaudeLander Linux ELF as artifact

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -54,3 +54,18 @@ jobs:
       - name: Run tests (ctest)
         run: |
           ctest --test-dir build --output-on-failure
+
+      - name: Verify Linux ELF binary exists
+        run: |
+          set -euo pipefail
+          BIN=build/bin/ClaudeLander
+          test -f "$BIN" || { echo "ERROR: $BIN not found"; exit 1; }
+          file "$BIN"
+          file "$BIN" | grep -q 'ELF 64-bit LSB.*x86-64'
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClaudeLander-linux-x64
+          path: build/bin/ClaudeLander
+          if-no-files-found: error


### PR DESCRIPTION
Closes #7

## Summary

`ci-linux.yml` builds the full game binary (`build/bin/ClaudeLander`)
but does not upload it.  This blocks the v1.0.0 release tag, which
needs both the Linux ELF and the Windows .exe attached as release
assets per the project plan.

This PR mirrors the artifact-upload step that already exists in
`ci-windows-cross.yml`:

1. Verify the produced binary is an `ELF 64-bit LSB ... x86-64`.
2. Upload it as `ClaudeLander-linux-x64` with `if-no-files-found: error`.

## Verification

CI on this branch must:
- [ ] Linux: build, ctest 439/439, verify ELF, upload artifact.
- [ ] Windows-cross, Windows-native, enforce-issue-linked-pr stay green.

After merge, the artifact appears on each main run; release tooling
can then `gh run download` it alongside the Windows artifact for
v1.0.0.

Built with [Claude](https://www.anthropic.com/claude) following CLAUDE.md.